### PR TITLE
Specify botorch version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,163 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# My stuffs
+RESULTS/

--- a/nlp_attack/README.md
+++ b/nlp_attack/README.md
@@ -6,7 +6,7 @@
 3. Install jsonnet: `conda install jsonnet -c conda-forge`
 4. Install pytorch: `conda install pytorch==1.10.1 torchvision==0.11.2 torchaudio==0.10.1 cudatoolkit=11.3 -c pytorch -c conda-forge`
 5. Install textattack: `cd TextAttack;pip install -e '.[tensorflow]'`
-6. Install botorch: `pip install botorch`
+6. Install botorch: `pip install botorch==0.6.4`
 7. Install dppy: `pip install dppy`
 8. Install allennlp: `pip install allennlp`
 9. Install allennlp-models: `pip install allennlp-models`

--- a/nlp_attack/generate_attack.py
+++ b/nlp_attack/generate_attack.py
@@ -1,0 +1,97 @@
+import os
+import argparse
+from collections import defaultdict
+import numpy as np
+
+
+wordnet = [
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-wordnet --model bert-base-uncased-ag-news --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pwws --max-patience 50",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-wordnet --model lstm-ag-news --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pwws --max-patience 50",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-wordnet --model xlnet-base-cased-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pwws --max-patience 100",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-wordnet --model bert-base-uncased-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pwws --max-patience 50",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-wordnet --model lstm-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pwws --max-patience 50",
+]
+
+embedding = [
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-embedding --model bert-base-uncased-ag-news --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type textfooler --max-patience 20",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-embedding --model lstm-ag-news --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type textfooler --max-patience 20",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-embedding --model xlnet-base-cased-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type textfooler --max-patience 20",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-embedding --model bert-base-uncased-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type textfooler --max-patience 20",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-embedding --model lstm-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type textfooler --max-patience 20",
+]
+
+hownet = [
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-hownet --model bert-base-uncased-ag-news --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pso --max-patience 100",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-hownet --model lstm-ag-news --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pso --max-patience 100",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-hownet --model xlnet-base-cased-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pso --max-patience 100",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-hownet --model bert-base-uncased-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pso --max-patience 100",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-hownet --model lstm-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pso --max-patience 100",
+]
+
+bert_attack = [
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-bert-attack --model bert-base-uncased-ag-news --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type bert-attack --max-patience 20",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-bert-attack --model lstm-ag-news --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type bert-attack --max-patience 20",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-bert-attack --model xlnet-base-cased-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type bert-attack --max-patience 20",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-bert-attack --model bert-base-uncased-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type bert-attack --max-patience 20",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-bert-attack --model lstm-mr --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type bert-attack --max-patience 20",
+]
+
+imdb = [
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-wordnet --model bert-base-uncased-imdb --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pwws --max-patience 100",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-embedding --model bert-base-uncased-imdb --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type textfooler --max-patience 20",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-hownet --model bert-base-uncased-imdb --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pso --max-patience 50",
+]
+
+nli = [
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-wordnet-pre --model bert-base-uncased-mnli --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pwws --max-patience 150",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-embedding-pre --model bert-base-uncased-mnli --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type textfooler --max-patience 50",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-hownet-pre --model bert-base-uncased-mnli --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pso --max-patience 150",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-wordnet-pre --model bert-base-uncased-qnli --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pwws --max-patience 150",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-embedding-pre --model bert-base-uncased-qnli --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type textfooler --max-patience 50",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-hownet-pre --model bert-base-uncased-qnli --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pso --max-patience 150",
+]
+
+yelp = [
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-wordnet --model bert-base-uncased-yelp --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pwws --max-patience 200",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-embedding --model bert-base-uncased-yelp --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type textfooler --max-patience 20",
+    "textattack attack --silent --shuffle --shuffle-seed 0 --random-seed 0 --recipe bayesattack-hownet --model bert-base-uncased-yelp --num-examples 500 --sidx 0 --pkl-dir RESULTS --post-opt v3 --use-sod --dpp-type dpp_posterior --max-budget-key-type pso --max-patience 50",
+]
+
+#cmds = wordnet + embedding + hownet
+cmds = bert_attack
+
+
+def get_job_name(cmd):
+    parts = cmd.split()
+    model = parts[11]
+    recipe = parts[9]
+
+    return f"{model}_{recipe}"
+
+
+def main(args):
+    template = open(args.template_path, "r").read()
+
+    f = open(f"{args.output_dir}/run.sh", "w")
+    f.write("#!/bin/bash\n\n")
+
+    for idx, cmd in enumerate(cmds):
+        job_name = get_job_name(cmd)
+        g = open(job_name+".sh", "w")
+        g.write(template.format(partition=args.partition, workspace=args.workspace, job_name=job_name, cmd=cmd))
+        g.close()
+
+        f.write(f"sbatch {job_name}.sh\n")
+
+    f.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--template_path", type=str, default="/root/new_attack/DiscreteBlockBayesAttack/nlp_attack/template_sbatch.txt")
+    parser.add_argument("--output_dir", type=str, default="/root/new_attack/DiscreteBlockBayesAttack/nlp_attack/")
+    parser.add_argument("--partition", type=str, default="applied")
+    parser.add_argument("--workspace", type=str, default="/root/new_attack/DiscreteBlockBayesAttack/nlp_attack")
+
+    args = parser.parse_args()
+    main(args)

--- a/nlp_attack/template_sbatch.txt
+++ b/nlp_attack/template_sbatch.txt
@@ -1,0 +1,42 @@
+#!/bin/bash
+#SBATCH --partition={partition}
+#SBATCH --output=/lustre/scratch/client/vinai/users/dangnm12/slurm/log/%x-%j.out
+#SBATCH --error=/lustre/scratch/client/vinai/users/dangnm12/slurm/log/%x-%j.out
+#SBATCH --job-name={job_name}
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --gpus-per-node=1
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=32G
+#SBATCH --mail-user=v.dangnm12@vinai.io
+#SBATCH --mail-type=END
+#SBATCH --mail-type=FAIL
+
+
+srun --container-image=/lustre/scratch/client/vinai/users/dangnm12/setup/docker_images/dc-miniconda3-py:38-4.10.3-cuda11.4.2-cudnn8-ubuntu20.04.sqsh \
+     --container-mounts=/lustre/scratch/client/vinai/users/dangnm12/:/root/ \
+     --container-workdir=/root/ \
+     /bin/bash -c \
+     "
+     export HTTP_PROXY=http://proxytc.vingroup.net:9090/
+     export HTTPS_PROXY=http://proxytc.vingroup.net:9090/
+     export http_proxy=http://proxytc.vingroup.net:9090/
+     export https_proxy=http://proxytc.vingroup.net:9090/
+
+     export HF_DATASETS_CACHE=/root/cache/huggingface/datasets
+     export TRANSFORMERS_CACHE=/root/cache/huggingface/transformers
+     export TFHUB_CACHE_DIR=/root/cache/tfhub_modules
+
+     export TF_FORCE_GPU_ALLOW_GROWTH=true 
+     export TRANSFORMERS_OFFLINE=0
+     export HF_DATASETS_OFFLINE=0
+     export TOKENIZERS_PARALLELISM=false
+
+     source /opt/conda/bin/activate
+
+     cd /root
+     conda activate /root/miniconda3/envs/bba
+
+     cd {workspace}
+     {cmd}
+     "


### PR DESCRIPTION
The latest release of BoTorch ([v0.6.5](https://github.com/pytorch/botorch/releases/tag/v0.6.5)) refactors `TrainingData` to `BotorchContainers` and `BotorchDatasets` so it will raise an error [here](https://github.com/snu-mllab/DiscreteBlockBayesAttack/blob/1dcac26674570dfb278ed40cd221279019a06c48/algorithms/bayesopt/surrogate_model/gp_regression_mixed.py#L15).